### PR TITLE
2. EventOutbox 개발

### DIFF
--- a/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEvent.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEvent.java
@@ -1,0 +1,3 @@
+package com.hojunnnnn.kafka_practice.order.application;
+
+public record OrderEvent(Long orderId) {}

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEventListener.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEventListener.java
@@ -1,0 +1,28 @@
+package com.hojunnnnn.kafka_practice.order.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OrderEventListener {
+
+    private final OrderEventOutboxManager orderEventOutboxManager;
+
+    /**
+     * 커밋 전(Before Commit)에 Outbox 를 저장한다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void saveEventOutbox(final OrderEvent event) {
+        log.info("🟢 saveEventOutbox : BEFORE_COMMIT 이벤트 수신 완료, orderId={}", event.orderId());
+        orderEventOutboxManager.save(event.orderId());
+        log.info("🟢 saveEventOutbox : BEFORE_COMMIT 이벤트 저장 완료, orderId={}", event.orderId());
+    }
+
+
+}

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEventOutboxManager.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEventOutboxManager.java
@@ -1,0 +1,21 @@
+package com.hojunnnnn.kafka_practice.order.application;
+
+import com.hojunnnnn.kafka_practice.order.domain.OrderEventOutbox;
+import com.hojunnnnn.kafka_practice.order.infra.OrderEventOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@RequiredArgsConstructor
+@Component
+public class OrderEventOutboxManager {
+
+    private final OrderEventOutboxRepository orderEventOutboxRepository;
+
+    @Transactional
+    public void save(final Long orderId) {
+        final OrderEventOutbox outbox = new OrderEventOutbox(orderId);
+        orderEventOutboxRepository.save(outbox);
+    }
+}

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderManager.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderManager.java
@@ -1,0 +1,20 @@
+package com.hojunnnnn.kafka_practice.order.application;
+
+import com.hojunnnnn.kafka_practice.order.domain.Order;
+import com.hojunnnnn.kafka_practice.order.infra.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class OrderManager {
+
+    private final OrderRepository orderRepository;
+
+    @Transactional
+    public void save(final Long orderId) {
+        final Order order = new Order(orderId);
+        orderRepository.save(order);
+    }
+}

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderService.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderService.java
@@ -1,10 +1,10 @@
 package com.hojunnnnn.kafka_practice.order.application;
 
-import com.hojunnnnn.kafka_practice.order.domain.Order;
-import com.hojunnnnn.kafka_practice.order.infra.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.hojunnnnn.kafka_practice.common.utils.DelayUtils.*;
 
@@ -13,13 +13,14 @@ import static com.hojunnnnn.kafka_practice.common.utils.DelayUtils.*;
 @Service
 public class OrderService {
 
-    private final OrderRepository orderRepository;
+    private final OrderManager orderManager;
 
+    @Transactional
     public void createOrder(final Long orderId) {
         // 1. 도메인 로직 수행
         log.info("🟢 createOrder : 주문 처리 시작, orderId={}", orderId);
         randomDelay();
-        orderRepository.save(new Order(orderId));
+        orderManager.save(orderId);
         log.info("🟢 createOrder : 주문 처리 완료, orderId={}", orderId);
 
         // TODO 2. Outbox table 에 이벤트를 저장하여 작업의 원자성 보장

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderService.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderService.java
@@ -14,6 +14,7 @@ import static com.hojunnnnn.kafka_practice.common.utils.DelayUtils.*;
 public class OrderService {
 
     private final OrderManager orderManager;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
     public void createOrder(final Long orderId) {
@@ -23,7 +24,8 @@ public class OrderService {
         orderManager.save(orderId);
         log.info("🟢 createOrder : 주문 처리 완료, orderId={}", orderId);
 
-        // TODO 2. Outbox table 에 이벤트를 저장하여 작업의 원자성 보장
+        // 2. Outbox table 에 이벤트를 저장하여 작업의 원자성 보장
+        applicationEventPublisher.publishEvent(new OrderEvent(orderId));
 
         // TODO 3. 주문 완료 이벤트 발행
     }

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/domain/OrderEventOutbox.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/domain/OrderEventOutbox.java
@@ -1,0 +1,31 @@
+package com.hojunnnnn.kafka_practice.order.domain;
+
+import com.hojunnnnn.kafka_practice.common.domain.BaseTimeEntity;
+import com.hojunnnnn.kafka_practice.order.domain.type.EventStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderEventOutbox extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "order_id", nullable = false)
+    private Long orderId;
+
+    @Column(name = "event_status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private EventStatus eventStatus;
+
+    public OrderEventOutbox(Long orderId) {
+        this.orderId = orderId;
+        this.eventStatus = EventStatus.INIT;
+    }
+}

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/domain/type/EventStatus.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/domain/type/EventStatus.java
@@ -1,0 +1,5 @@
+package com.hojunnnnn.kafka_practice.order.domain.type;
+
+public enum EventStatus {
+    INIT, PUBLISHED, FAILED;
+}

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/infra/OrderEventOutboxRepository.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/infra/OrderEventOutboxRepository.java
@@ -1,0 +1,7 @@
+package com.hojunnnnn.kafka_practice.order.infra;
+
+import com.hojunnnnn.kafka_practice.order.domain.OrderEventOutbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderEventOutboxRepository extends JpaRepository<OrderEventOutbox, Long> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,3 @@ spring:
         format_sql: true
     hibernate:
       ddl-auto: create
-    defer-datasource-initialization: true
-  sql:
-    init:
-      mode: always


### PR DESCRIPTION
## Summary
- OrderManager 클래스 도입
  - OrderRepository에 대한 도메인 영속 책임을 OrderManager로 위임하여, OrderService는 비즈니스 로직과 트랜잭션 흐름에 집중할 수 있도록 리팩토링
- OrderEventOutbox 엔티티 생성
  - 일반적으로 아래와 같은 필드를 포함하지만, 이 프로젝트에선 간소화된 형태로 구성
 
<img width="254" height="325" alt="image" src="https://github.com/user-attachments/assets/4f0daa0a-2431-489e-98a2-ca0570b875ef" />

- Outbox Event 저장 로직 구현
  - 주문 트랜잭션 내부에서 Outbox 테이블에 이벤트를 저장하여 비즈니스 로직과 이벤트 발행의 원자성을 보장