### PR TITLE
이벤트 스케쥴러 구현

### DIFF
--- a/src/main/java/com/hojunnnnn/kafka_practice/message_queue/kafka/producer/application/OrderEventKafkaProducer.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/message_queue/kafka/producer/application/OrderEventKafkaProducer.java
@@ -1,7 +1,7 @@
 package com.hojunnnnn.kafka_practice.message_queue.kafka.producer.application;
 
 import com.hojunnnnn.kafka_practice.order.application.OrderCompletedEvent;
-import com.hojunnnnn.kafka_practice.order.application.OrderEventOutboxService;
+import com.hojunnnnn.kafka_practice.order.application.OrderEventOutboxManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -15,7 +15,7 @@ import static com.hojunnnnn.kafka_practice.message_queue.kafka._const.KafkaConst
 public class OrderEventKafkaProducer {
 
     private final KafkaTemplate<String, String> kafkaDefaultTemplate;
-    private final OrderEventOutboxService orderEventOutboxService;
+    private final OrderEventOutboxManager orderEventOutboxManager;
 
     public void publishOrderCompletedEvent(final OrderCompletedEvent event) {
         kafkaDefaultTemplate
@@ -24,12 +24,12 @@ public class OrderEventKafkaProducer {
                     if (ex == null) {
                         log.info("🟢 카프카 이벤트 발행 성공, orderId={} with offset={}",
                                 event.orderId(), result.getRecordMetadata().offset());
-                        orderEventOutboxService.publishCompleted(event.orderId());
+                        orderEventOutboxManager.published(event.orderId());
                         log.info("🟢 EventOutbox PUBLISHED 업데이트 완료, orderId={}", event.orderId());
                     } else {
                         log.error("🔴 카프카 이벤트 발행 실패, orderId={} due to: {}",
                                 event.orderId(), ex.getMessage());
-                        orderEventOutboxService.publishFailed(event.orderId());
+                        orderEventOutboxManager.failed(event.orderId());
                         log.error("🔴 EventOutbox FAILED 업데이트 완료, orderId={}", event.orderId());
                     }
                 });

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEventOutboxManager.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEventOutboxManager.java
@@ -6,6 +6,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @RequiredArgsConstructor
 @Component
 public class OrderEventOutboxManager {
@@ -28,5 +31,10 @@ public class OrderEventOutboxManager {
     public void failed(final Long orderId) {
         orderEventOutboxRepository.findByOrderId(orderId)
                 .ifPresent(OrderEventOutbox::failed);
+    }
+
+    @Transactional(readOnly = true)
+    public List<OrderEventOutbox> getFailedEvents() {
+        return orderEventOutboxRepository.findAllFailedEvents(LocalDateTime.now().minusMinutes(5));
     }
 }

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEventOutboxManager.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEventOutboxManager.java
@@ -37,4 +37,9 @@ public class OrderEventOutboxManager {
     public List<OrderEventOutbox> getFailedEvents() {
         return orderEventOutboxRepository.findAllFailedEvents(LocalDateTime.now().minusMinutes(5));
     }
+
+    @Transactional
+    public void deletePublishedEvent() {
+        orderEventOutboxRepository.deleteAllPublishedEvents(LocalDateTime.now().minusDays(7));
+    }
 }

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEventOutboxService.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEventOutboxService.java
@@ -36,6 +36,6 @@ public class OrderEventOutboxService {
     }
 
     public void deleteOldPublishedEvents() {
-
+        orderEventOutboxManager.deletePublishedEvent();
     }
 }

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEventOutboxService.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEventOutboxService.java
@@ -1,13 +1,20 @@
 package com.hojunnnnn.kafka_practice.order.application;
 
+import com.hojunnnnn.kafka_practice.message_queue.kafka.producer.application.OrderEventKafkaProducer;
+import com.hojunnnnn.kafka_practice.order.domain.OrderEventOutbox;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class OrderEventOutboxService {
 
     private final OrderEventOutboxManager orderEventOutboxManager;
+    private final OrderEventKafkaProducer orderEventKafkaProducer;
 
     public void save(final Long orderId) {
         orderEventOutboxManager.save(orderId);
@@ -19,5 +26,16 @@ public class OrderEventOutboxService {
 
     public void publishFailed(final Long orderId) {
         orderEventOutboxManager.failed(orderId);
+    }
+
+    public void retryFailedEvents() {
+        orderEventOutboxManager.getFailedEvents()
+                .forEach(event ->  {
+                    orderEventKafkaProducer.publishOrderCompletedEvent(new OrderCompletedEvent(event.getOrderId()));
+                });
+    }
+
+    public void deleteOldPublishedEvents() {
+
     }
 }

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/infra/OrderEventOutboxRepository.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/infra/OrderEventOutboxRepository.java
@@ -2,6 +2,7 @@ package com.hojunnnnn.kafka_practice.order.infra;
 
 import com.hojunnnnn.kafka_practice.order.domain.OrderEventOutbox;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
@@ -17,4 +18,11 @@ public interface OrderEventOutboxRepository extends JpaRepository<OrderEventOutb
             "WHERE (oeo.eventStatus = 'FAILED' OR oeo.eventStatus = 'INIT') " +
             "AND oeo.createdDateTime < :dateTime")
     List<OrderEventOutbox> findAllFailedEvents(LocalDateTime dateTime);
+
+    @Modifying
+    @Query("DELETE " +
+            "FROM OrderEventOutbox oeo " +
+            "WHERE oeo.eventStatus = 'PUBLISHED' " +
+            "AND oeo.createdDateTime < :dateTime")
+    void deleteAllPublishedEvents(LocalDateTime dateTime);
 }

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/infra/OrderEventOutboxRepository.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/infra/OrderEventOutboxRepository.java
@@ -2,10 +2,19 @@ package com.hojunnnnn.kafka_practice.order.infra;
 
 import com.hojunnnnn.kafka_practice.order.domain.OrderEventOutbox;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface OrderEventOutboxRepository extends JpaRepository<OrderEventOutbox, Long> {
 
     Optional<OrderEventOutbox> findByOrderId(Long orderId);
+
+    @Query("SELECT oeo " +
+            "FROM OrderEventOutbox oeo " +
+            "WHERE (oeo.eventStatus = 'FAILED' OR oeo.eventStatus = 'INIT') " +
+            "AND oeo.createdDateTime < :dateTime")
+    List<OrderEventOutbox> findAllFailedEvents(LocalDateTime dateTime);
 }

--- a/src/main/java/com/hojunnnnn/kafka_practice/scheduler/OrderEventScheduler.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/scheduler/OrderEventScheduler.java
@@ -2,8 +2,11 @@ package com.hojunnnnn.kafka_practice.scheduler;
 
 import com.hojunnnnn.kafka_practice.order.application.OrderEventOutboxService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class OrderEventScheduler {
@@ -12,16 +15,20 @@ public class OrderEventScheduler {
 
     /**
      * 실패한 이벤트를 재발행한다.
+     * 조건 > INIT 또는 FAILED 상태의 이벤트
+     *     > createDateTime 이 현재 시간 기준 5분 이상 지난 이벤트
      */
+    @Scheduled(fixedDelay = 60000)
     public void retryFailedEvents() {
-
+        log.info("🟢 Retry Failed Order Events Scheduler Executed");
+        orderEventOutboxService.retryFailedEvents();
     }
 
     /**
-     * 발행된 오래된 이벤트를 삭제한다.
+     * 발행된 이벤트를 삭제한다.
      */
     public void deletePublishedEvents() {
-
+        orderEventOutboxService.deleteOldPublishedEvents();
     }
 
 }

--- a/src/main/java/com/hojunnnnn/kafka_practice/scheduler/OrderEventScheduler.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/scheduler/OrderEventScheduler.java
@@ -26,8 +26,12 @@ public class OrderEventScheduler {
 
     /**
      * 발행된 이벤트를 삭제한다.
+     * 조건 > PUBLISHED 상태의 이벤트
+     *      > createDateTime 이 현재 시간 기준 7일 이상 지난 이벤트
      */
+    @Scheduled(fixedDelay =  60000)
     public void deletePublishedEvents() {
+        log.info("🟢 Delete Published Order Events Scheduler Executed");
         orderEventOutboxService.deleteOldPublishedEvents();
     }
 

--- a/src/main/java/com/hojunnnnn/kafka_practice/scheduler/OrderEventScheduler.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/scheduler/OrderEventScheduler.java
@@ -1,0 +1,27 @@
+package com.hojunnnnn.kafka_practice.scheduler;
+
+import com.hojunnnnn.kafka_practice.order.application.OrderEventOutboxService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class OrderEventScheduler {
+
+    private final OrderEventOutboxService orderEventOutboxService;
+
+    /**
+     * 실패한 이벤트를 재발행한다.
+     */
+    public void retryFailedEvents() {
+
+    }
+
+    /**
+     * 발행된 오래된 이벤트를 삭제한다.
+     */
+    public void deletePublishedEvents() {
+
+    }
+
+}

--- a/src/main/java/com/hojunnnnn/kafka_practice/scheduler/config/SchedulerConfig.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/scheduler/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.hojunnnnn.kafka_practice.scheduler.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulerConfig {
+}


### PR DESCRIPTION
- `OrderEventScheduler`를 통해 주기적으로 실패한 이벤트를 재시도하고, 오래된 이벤트를 삭제한다.
  - `retryFailedEvents` 메서드는 `INIT` 또는 `FAILED`상태인 이벤트를 재발행
  - `deletePublishedEvents` 메서드는 발행 후 일정 시간이 지난 이벤트를 삭제
- 이로써 Transactional Outbox Pattern의 핵심 철학인 Eventual Consistency를 보장한다.