### PR TITLE
7. 카프카 이벤트 소비 로직 구현

### DIFF
--- a/src/main/java/com/hojunnnnn/kafka_practice/message_queue/kafka/consumer/application/OrderEventKafkaConsumer.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/message_queue/kafka/consumer/application/OrderEventKafkaConsumer.java
@@ -1,5 +1,6 @@
 package com.hojunnnnn.kafka_practice.message_queue.kafka.consumer.application;
 
+import com.hojunnnnn.kafka_practice.order.application.OrderEventInboxService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -15,13 +16,26 @@ import static com.hojunnnnn.kafka_practice.message_queue.kafka._const.KafkaConst
 @Component
 public class OrderEventKafkaConsumer {
 
+    private final OrderEventInboxService orderEventInboxService;
+
     @KafkaListener(
             topics = FCT_ORDER_COMPLETED,
             groupId = ORDER_CONSUMER_GROUP_0,
             containerFactory = "kafkaListenerContainerFactory"
     )
     public void messageListener(ConsumerRecord<String, String> record, Acknowledgment ack) {
-        log.info("🟢 카프카 이벤트 수신 완료, value={}, offset={}", record.value(), record.offset());
-        ack.acknowledge();
+        try {
+            log.info("🟢 컨슈머 이벤트 수신 완료, value={}, offset={}", record.value(), record.offset());
+            orderEventInboxService.processOrderEvent(Long.parseLong(record.value()));
+            log.info("🟢 컨슈머 로직 처리 완료, value={}, offset={}", record.value(), record.offset());
+
+            // 모든 처리가 완료된 후 Kafka 에 ACK 전송
+            ack.acknowledge();
+            log.info("🟢 카프카 ACK 전송 완료, offset={}", record.offset());
+        } catch (Exception e) {
+            // 예외 발생 시 ACK 전송하지 않음
+            log.error("🔴 컨슈머 이벤트 처리 중 오류 발생, value={}, offset={}, error={}", record.value(), record.offset(), e.getMessage());
+            // 세밀한 제어가 필요할 경우 재처리 로직을 추가(DLQ, 재시도 토픽 등)
+        }
     }
 }

--- a/src/main/java/com/hojunnnnn/kafka_practice/message_queue/kafka/consumer/domain/type/InboxStatus.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/message_queue/kafka/consumer/domain/type/InboxStatus.java
@@ -1,7 +1,0 @@
-package com.hojunnnnn.kafka_practice.message_queue.kafka.consumer.domain.type;
-
-public enum InboxStatus {
-    PROCESSING,
-    COMPLETED,
-    FAILED
-}

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEventInboxService.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderEventInboxService.java
@@ -1,0 +1,46 @@
+package com.hojunnnnn.kafka_practice.order.application;
+
+import com.hojunnnnn.kafka_practice.order.domain.OrderEventInbox;
+import com.hojunnnnn.kafka_practice.order.infra.OrderEventInboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.hojunnnnn.kafka_practice.message_queue.kafka._const.KafkaConst.ConsumerGroup.ORDER_CONSUMER_GROUP_0;
+import static com.hojunnnnn.kafka_practice.order.domain.type.InboxStatus.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class OrderEventInboxService {
+
+    private final OrderNotificationSender orderNotificationSender;
+    private final OrderEventInboxRepository orderEventInboxRepository;
+
+
+    @Transactional
+    public void processOrderEvent(final Long orderId) {
+        // 1. 이미 처리된 이벤트인지 확인
+        String eventId = String.valueOf(orderId);
+        if(orderEventInboxRepository.existsByEventIdAndConsumerId(eventId, ORDER_CONSUMER_GROUP_0)) {
+            log.info("🟠 이미 처리된 이벤트 입니다. eventId={}, consumerId={}", eventId, ORDER_CONSUMER_GROUP_0);
+            return;
+        }
+
+        // 2. EventInbox 에 이벤트 기록
+        OrderEventInbox eventInbox = new OrderEventInbox(
+                eventId,
+                ORDER_CONSUMER_GROUP_0,
+                PROCESSING,
+                "ORDER_EVENT");
+        OrderEventInbox savedInbox = orderEventInboxRepository.save(eventInbox);
+
+        // 3. 비즈니스 로직 처리
+        orderNotificationSender.sendOrderCompleted(orderId);
+
+        // 4. 처리 완료 후 EventInbox 상태 업데이트
+        savedInbox.completed();
+        orderEventInboxRepository.save(savedInbox);
+    }
+}

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderNotificationSender.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/application/OrderNotificationSender.java
@@ -1,0 +1,22 @@
+package com.hojunnnnn.kafka_practice.order.application;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.hojunnnnn.kafka_practice.common.utils.DelayUtils.randomDelay;
+
+@Slf4j
+@Service
+public class OrderNotificationSender {
+
+    @Transactional
+    public void sendOrderCompleted(Long orderId) {
+        // 예: 이메일, SMS, 푸시 알림 등
+        log.info("🟢 sendOrderNotification : 주문 완료 알림 전송 시작, orderId={}", orderId);
+
+        randomDelay();
+
+        log.info("🟢 sendOrderNotification : 주문 완료 알림 전송 완료, orderId={}", orderId);
+    }
+}

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/domain/OrderEventInbox.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/domain/OrderEventInbox.java
@@ -1,7 +1,7 @@
-package com.hojunnnnn.kafka_practice.message_queue.kafka.consumer.domain;
+package com.hojunnnnn.kafka_practice.order.domain;
 
 import com.hojunnnnn.kafka_practice.common.domain.BaseTimeEntity;
-import com.hojunnnnn.kafka_practice.message_queue.kafka.consumer.domain.type.InboxStatus;
+import com.hojunnnnn.kafka_practice.order.domain.type.InboxStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"event_id", "consumer_id"}))
 @Entity
-public class EventInbox extends BaseTimeEntity {
+public class OrderEventInbox extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,11 +30,15 @@ public class EventInbox extends BaseTimeEntity {
     @Column(name = "event_type", nullable = false)
     private String eventType;
 
-    public EventInbox(String eventId, String consumerId, InboxStatus inboxStatus, String eventType) {
+    public OrderEventInbox(String eventId, String consumerId, InboxStatus inboxStatus, String eventType) {
         this.eventId = eventId;
         this.consumerId = consumerId;
         this.inboxStatus = inboxStatus;
         this.eventType = eventType;
+    }
+
+    public void completed() {
+        this.inboxStatus = InboxStatus.COMPLETED;
     }
 }
 

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/domain/type/InboxStatus.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/domain/type/InboxStatus.java
@@ -1,0 +1,7 @@
+package com.hojunnnnn.kafka_practice.order.domain.type;
+
+public enum InboxStatus {
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/hojunnnnn/kafka_practice/order/infra/OrderEventInboxRepository.java
+++ b/src/main/java/com/hojunnnnn/kafka_practice/order/infra/OrderEventInboxRepository.java
@@ -1,0 +1,10 @@
+package com.hojunnnnn.kafka_practice.order.infra;
+
+import com.hojunnnnn.kafka_practice.order.domain.OrderEventInbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderEventInboxRepository extends JpaRepository<OrderEventInbox, Long> {
+
+    boolean existsByEventIdAndConsumerId(String eventId, String consumerId);
+
+}


### PR DESCRIPTION
## Summary
- Consumer의 모든 작업이 완료되면 ack 를 전송하고, 실패하면 ack를 전송하지 않고 재시도
  - 트랜잭션 경계를 `OrderEventInboxService` 안으로 설정
    - 이미 처리된 이벤트인지 먼저 확인하여 중복 처리를 방지 (Idempotent)
    - 비즈니스 로직과 이벤트를 기록하는 로직을 하나의 트랜잭션으로 관리하여 작업의 원자성 확보
- 이를 통해 Exactly-Once에 가까운 효과를 보장